### PR TITLE
MA-1283 Add support for units, PO boxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# IntelliJ
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
+# Why fork?
+
+OpenCageDate/address-formatting does not support (and does not seem to plan to support) postal address features like
+units, PO boxes, etc. We augment the formatting model to include this.
+
+## Run tests locally
+
+### First time set-up
+
+You will need to install the `Geo::Address::Formatter` the first time you set up to run tests
+
+```zsh
+cpan
+> install Geo::Address::Formatter
+```
+
+###
+
+```zsh
+perl bin/run_tests.t
+````
+
+The repository's original README is retained below:
+
 # address formatting
 
 ### Overview

--- a/conf/components.yaml
+++ b/conf/components.yaml
@@ -1,4 +1,10 @@
 # ordered list, smallest to largest
+name: unit
+aliases:
+    - level
+    - staircase
+    - entrance
+---
 name: house_number
 aliases:
     - street_number
@@ -11,6 +17,7 @@ aliases:
     - isolated_dwelling
     - farmland
     - allotments
+    - po_box
 ---
 name: road
 aliases:

--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -31,7 +31,7 @@ generic3: &generic3 |
 generic4: &generic4 |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}} {{{road}}}
+        {{{house_number}}} {{{road}}} {{unit}}
         {{#first}} {{{village}}} || {{{hamlet}}} {{/first}}
         {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} || {{{suburb}}} || {{{municipality}}} || {{{county}}} {{/first}}, {{#first}} {{{state_code}}} || {{{state}}} {{/first}} {{{postcode}}}
         {{{country}}}
@@ -214,7 +214,7 @@ fallback1: &fallback1 |
 fallback2: &fallback2 |
         {{{attention}}}
         {{{house}}}
-        {{{road}}} {{{house_number}}}
+        {{{road}}} {{{house_number}}} {{unit}}
         {{{place}}}
         {{#first}} {{{suburb}}} || {{{village}}} || {{{hamlet}}} {{/first}}
         {{#first}} {{{city}}} || {{{town}}} || {{{municipality}}} || {{{county}}} || {{{island}}} || {{{state_district}}} {{/first}}, {{#first}} {{{state}}} || {{{state_code}}} {{/first}}

--- a/testcases/countries/us.yaml
+++ b/testcases/countries/us.yaml
@@ -268,3 +268,29 @@ expected:  |
     Homestead Trailer Park
     Homestead, FL 33030
     United States of America
+---
+description: unit
+components:
+    city: Tampa
+    country: United States of America
+    country_code: us
+    house_number: 1099
+    postcode: 33602
+    road: Treasure St
+    state: Florida
+    unit: Apt 600
+expected:  |
+    1099 Treasure St Apt 600
+    Tampa, FL 33602
+    United States of America
+---
+description: po_box
+components:
+    city: Austin
+    country_code: us
+    po_box: PO Box 304
+    postcode: 78701
+    state: TX
+expected: |
+    PO Box 304
+    Austin, TX 78701


### PR DESCRIPTION
## What & Why
<!-- Describe your change, and why you made it. -->

Add support for adding units to the address formatter. This will allow us to support complete postal addresses (at least, for the US) without doing hacky post-processing.

## Proof
<!-- A picture is worth a thousand words; provide some visual proof of your changes working. -->

Ran tests and saw that they passed:

```
ok 259 - us - unit
ok 260 - us - po_box
```
